### PR TITLE
chore: build app before start

### DIFF
--- a/Desktop/glass-main/package.json
+++ b/Desktop/glass-main/package.json
@@ -6,7 +6,7 @@
     "main": "src/index.js",
     "scripts": {
         "setup": "npm install && cd pickleglass_web && npm install && npm run build && cd .. && npm start",
-        "start": "npm run build:renderer && electron .",
+        "start": "npm run build:all && electron .",
         "package": "npm run build:all && electron-builder --dir",
         "make": "npm run build:renderer && electron-forge make",
         "build": "npm run build:all && electron-builder --config electron-builder.yml --publish never",


### PR DESCRIPTION
## Summary
- run full build before starting electron

## Testing
- `npm start` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa743d784832b86901fb32cfb13e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop app startup to perform a full build (renderer + web) before launch, replacing the previous renderer-only build. This ensures all components are compiled ahead of time for a consistent startup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->