### PR TITLE
Ensure web build installs dependencies first

### DIFF
--- a/Desktop/glass-main/package.json
+++ b/Desktop/glass-main/package.json
@@ -15,7 +15,7 @@
         "lint": "eslint --ext .ts,.tsx,.js .",
         "postinstall": "electron-builder install-app-deps",
         "build:renderer": "node build.js",
-        "build:web": "cd pickleglass_web && npm run build && cd ..",
+        "build:web": "cd pickleglass_web && npm install && npm run build && cd ..",
         "build:all": "npm run build:renderer && npm run build:web",
         "watch:renderer": "node build.js --watch"
     },


### PR DESCRIPTION
## Summary
- run `npm install` inside `pickleglass_web` before building it

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68baa948bc54832b918edba2816eaf2b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the web build process to automatically install dependencies before building, ensuring smoother, more reliable builds.

* **Bug Fixes**
  * Addressed intermittent build failures caused by missing or outdated dependencies during the web build step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->