### PR TITLE
Add Node test script and sample test

### DIFF
--- a/Desktop/glass-main/package.json
+++ b/Desktop/glass-main/package.json
@@ -17,7 +17,8 @@
         "build:renderer": "node build.js",
         "build:web": "cd pickleglass_web && npm install && npm run build && cd ..",
         "build:all": "npm run build:renderer && npm run build:web",
-        "watch:renderer": "node build.js --watch"
+        "watch:renderer": "node build.js --watch",
+        "test": "node --test"
     },
     "keywords": [
         "glass",

--- a/Desktop/glass-main/test/sample.test.js
+++ b/Desktop/glass-main/test/sample.test.js
@@ -1,0 +1,6 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+test('basic arithmetic', () => {
+  assert.strictEqual(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- add npm `test` script using Node's built-in test runner
- include a sample arithmetic test under `test/`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baac4891ac832b91e79faaec5eba67