### PR TITLE
chore: add basic eslint config

### DIFF
--- a/Desktop/glass-main/eslint.config.js
+++ b/Desktop/glass-main/eslint.config.js
@@ -1,0 +1,28 @@
+export default [
+  {
+    ignores: [
+      "pickleglass_web/**",
+      "public/**",
+      "src/ui/assets/**",
+      "eslint.config.js"
+    ],
+  },
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: "commonjs",
+      globals: {
+        require: "readonly",
+        module: "readonly",
+        __dirname: "readonly",
+        process: "readonly",
+        console: "readonly"
+      }
+    },
+    rules: {
+      "no-unused-vars": "warn",
+      "no-undef": "error"
+    }
+  }
+];


### PR DESCRIPTION
## Summary
- add flat ESLint configuration and ignore web assets

## Testing
- `npm install --save-dev eslint eslint-config-prettier` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: 272 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68baadda62f8832babf3e3cc93ce58db