### PR TITLE
chore: add jest test framework

### DIFF
--- a/Desktop/glass-main/package.json
+++ b/Desktop/glass-main/package.json
@@ -18,7 +18,7 @@
         "build:web": "cd pickleglass_web && npm install && npm run build && cd ..",
         "build:all": "npm run build:renderer && npm run build:web",
         "watch:renderer": "node build.js --watch",
-        "test": "node --test"
+        "test": "jest"
     },
     "keywords": [
         "glass",
@@ -65,6 +65,7 @@
         "electron-builder": "^26.0.12",
         "electron-reloader": "^1.2.3",
         "esbuild": "^0.25.5",
+        "jest": "^29.7.0",
         "prettier": "^3.6.2"
     },
     "optionalDependencies": {

--- a/Desktop/glass-main/src/app.test.js
+++ b/Desktop/glass-main/src/app.test.js
@@ -1,0 +1,3 @@
+test('basic test', () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add jest dev dependency and test script
- add basic sample test

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bab08a97d0832b98d02b230ff0bac4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Migrated project to use Jest as the test runner.
  * Added an initial passing test to confirm the testing setup.
  * No changes to product behavior.

* **Chores**
  * Updated the test script to run with the new test framework.
  * Added the required development dependency for the test runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->