### PR TITLE
feat: add dev script and improve startup guidance

### DIFF
--- a/Desktop/glass-main/README.md
+++ b/Desktop/glass-main/README.md
@@ -51,6 +51,14 @@ node --version
 npm run setup
 ```
 
+### Launch in Development
+
+```bash
+npm run dev
+```
+
+This builds the web client, starts the renderer and web servers, and launches the Electron app.
+
 ## Highlights
 
 

--- a/Desktop/glass-main/package.json
+++ b/Desktop/glass-main/package.json
@@ -18,6 +18,8 @@
         "build:web": "cd pickleglass_web && npm install && npm run build && cd ..",
         "build:all": "npm run build:renderer && npm run build:web",
         "watch:renderer": "node build.js --watch",
+        "web:dev": "cd pickleglass_web && npm run dev",
+        "dev": "npm run build:web && concurrently \"npm run watch:renderer\" \"npm run web:dev\" && electron .",
         "test": "jest"
     },
     "keywords": [
@@ -66,7 +68,8 @@
         "electron-reloader": "^1.2.3",
         "esbuild": "^0.25.5",
         "jest": "^29.7.0",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "concurrently": "^8.2.2"
     },
     "optionalDependencies": {
         "electron-liquid-glass": "^1.0.1"

--- a/Desktop/glass-main/src/index.js
+++ b/Desktop/glass-main/src/index.js
@@ -684,10 +684,11 @@ async function startWebStack() {
     console.error(`============================================================`);
     console.error(`[ERROR] Frontend build directory not found!`);
     console.error(`Path: ${staticDir}`);
-    console.error(`Please run 'npm run build' inside the 'pickleglass_web' directory first.`);
+    console.error(`Run 'npm run dev' to build and start the application.`);
     console.error(`============================================================`);
-    app.quit();
-    return;
+    throw new Error(
+      `Frontend build directory not found. Run 'npm run dev' to build and start the application.`
+    );
   }
 
   const runtimeConfig = {


### PR DESCRIPTION
## Summary
- add `dev` and `web:dev` scripts for easier development workflow
- provide clear startup message when frontend build is missing
- document new development launch steps

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: no-undef and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bab3afbb9c832b9cbdca75ae514f08