### PR TITLE
Use official npm registry for Glass setup

### DIFF
--- a/Desktop/glass-main/.npmrc
+++ b/Desktop/glass-main/.npmrc
@@ -1,3 +1,3 @@
-registry=https://registry.npmmirror.com/
+registry=https://registry.npmjs.org/
 better-sqlite3:ignore-scripts=true
 sharp:ignore-scripts=true


### PR DESCRIPTION
## Summary
- point `.npmrc` to the official `https://registry.npmjs.org/`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/concurrently)*

------
https://chatgpt.com/codex/tasks/task_e_68bab7e1cd30832b8baea9a0f1c54465